### PR TITLE
[bugfix] minimize docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ARG ALPINE_VERSION="3.17"
 FROM --platform=$BUILDPLATFORM alpine:$ALPINE_VERSION as tor-builder
 
 ARG TOR_VERSION="0.4.7.13"
-RUN apk update
-RUN apk add --no-cache git build-base automake autoconf make build-base openssl-dev libevent-dev zlib-dev
+RUN apk add --update --no-cache git build-base automake autoconf make build-base openssl-dev libevent-dev zlib-dev
 
 # Install Tor from source
 RUN git clone https://gitlab.torproject.org/tpo/core/tor.git --depth 1 --branch tor-$TOR_VERSION /tor
@@ -38,9 +37,7 @@ RUN --mount=target=. \
 FROM --platform=$BUILDPLATFORM alpine:$ALPINE_VERSION as runner
 WORKDIR /root/
 
-RUN apk update
-RUN apk add --no-cache libevent \
-    && rm -rf /var/cache/apk/*
+RUN apk add --update --no-cache libevent
 
 # install tor
 RUN mkdir -p /usr/local/bin /usr/local/etc/tor /usr/local/share/tor

--- a/Dockerfile.obfs4
+++ b/Dockerfile.obfs4
@@ -9,6 +9,7 @@ RUN git clone https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transp
 
 # Build the obfs4 binary
 FROM --platform=$BUILDPLATFORM golang:1.17-alpine as builder
+RUN echo 'nobody:x:65534:65534:Nobody:/:' > /tmp/passwd
 
 # Build
 RUN mkdir /out
@@ -21,5 +22,6 @@ RUN --mount=target=. \
 
 FROM scratch
 USER nobody
+COPY --from=builder /tmp/passwd /etc/passwd
 COPY --from=builder /out/obfs4proxy /
 ENTRYPOINT ["/obfs4proxy"]

--- a/Dockerfile.obfs4
+++ b/Dockerfile.obfs4
@@ -17,13 +17,9 @@ RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     --mount=type=bind,from=git,source=/obfs,target=/obfs \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/obfs4proxy ./obfs4proxy
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/obfs4proxy ./obfs4proxy
 
-# Use distroless as minimal base image to package the obfs binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /out/obfs4proxy .
-USER 65532:65532
-
+FROM scratch
+USER nobody
+COPY --from=builder /out/obfs4proxy /
 ENTRYPOINT ["/obfs4proxy"]


### PR DESCRIPTION
You have a bug here.

```Dockerfile
RUN apk update
RUN apk add --no-cache libevent \
    && rm -rf /var/cache/apk/*
```

You have two layers here and a problem with the cache:

1. In the first layer, you created a cache, so it can't be deleted later
2. In the second layer, you added a delete mark to the cache, so it's modified. You have a second copy of a cache here.

So, there are two copies of cache in layers, not zero.

Here is a fix :3