### PR TITLE
Update tor version to 0.4.8.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VERSION="3.17.3"
+ARG ALPINE_VERSION="3.18.4"
 
 # Tor builder
 FROM --platform=$TARGETPLATFORM docker.io/library/alpine:$ALPINE_VERSION as tor-builder
@@ -13,10 +13,14 @@ RUN apk add --update --no-cache \
 RUN git clone https://gitlab.torproject.org/tpo/core/tor.git --depth 1 --branch tor-$TOR_VERSION /tor
 WORKDIR /tor
 RUN ./autogen.sh
+
+# Notes:
+# - --enable-gpl is required to compile PoW anti-DoS: https://community.torproject.org/onion-services/advanced/dos/
 RUN ./configure \
     --disable-asciidoc \
     --disable-manpage \
-    --disable-html-manual
+    --disable-html-manual \
+    --enable-gpl
     # --enable-static-tor
 RUN make
 RUN make install
@@ -44,8 +48,11 @@ LABEL \
 
 WORKDIR /app
 
-RUN apk add --update --no-cache libevent && \
-    chmod -R g+w /app /run
+RUN apk add --update --no-cache \
+    libevent \
+    xz-libs \
+    zstd-libs \
+    && chmod -R g+w /app /run
 
 # install tor
 RUN mkdir -p /usr/local/bin /usr/local/etc/tor /usr/local/share/tor

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG ALPINE_VERSION="3.17.3"
 # Tor builder
 FROM --platform=$TARGETPLATFORM docker.io/library/alpine:$ALPINE_VERSION as tor-builder
 
-ARG TOR_VERSION="0.4.7.13"
+ARG TOR_VERSION="0.4.8.7"
 RUN apk add --update --no-cache \
     git build-base automake autoconf make \
     build-base openssl-dev libevent-dev zlib-dev \

--- a/Dockerfile.quick
+++ b/Dockerfile.quick
@@ -1,4 +1,4 @@
-ARG ALPINE_VERSION="3.17.3"
+ARG ALPINE_VERSION="3.18.4"
 
 # Build the obfs4 binary (cross-compiling)
 FROM --platform=$BUILDPLATFORM golang:1.20-alpine as obfs-builder

--- a/Dockerfile.quick
+++ b/Dockerfile.quick
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 # Tor runner
 FROM --platform=$TARGETPLATFORM docker.io/library/alpine:$ALPINE_VERSION as runner
-ARG TOR_VERSION="0.4.7.13"
+ARG TOR_VERSION="0.4.8.7"
 
 LABEL \
       org.opencontainers.image.source "https://github.com/bugfest/tor-docker"

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ build:
 	docker buildx build \
 		--platform=linux/amd64,linux/arm,linux/arm64 \
 		--build-arg ALPINE_VERSION=3.17.3 \
-		--build-arg TOR_VERSION=0.4.7.13 \
-		--tag quay.io/bugfest/tor:0.4.7.13 \
+		--build-arg TOR_VERSION=0.4.8.7 \
+		--tag quay.io/bugfest/tor:0.4.8.7 \
 		--tag quay.io/bugfest/tor:latest \
 		--squash \
 		-f Dockerfile.quick \
@@ -18,8 +18,8 @@ build-alt:
 	docker buildx build \
 		--platform=linux/amd64,linux/arm,linux/arm64 \
 		--build-arg ALPINE_VERSION=3.17.3 \
-		--build-arg TOR_VERSION=0.4.7.13 \
-		--tag quay.io/bugfest/tor:0.4.7.13 \
+		--build-arg TOR_VERSION=0.4.8.7 \
+		--tag quay.io/bugfest/tor:0.4.8.7 \
 		--tag quay.io/bugfest/tor:latest \
 		--squash \
 		-f Dockerfile \

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: all
 all: build
 
+# Dockerfile.quick installs Tor using pre-built binaries
 .PHONY: quick
-build:
+quick:
 	docker buildx build \
 		--platform=linux/amd64,linux/arm,linux/arm64 \
-		--build-arg ALPINE_VERSION=3.17.3 \
 		--build-arg TOR_VERSION=0.4.8.7 \
 		--tag quay.io/bugfest/tor:0.4.8.7 \
 		--tag quay.io/bugfest/tor:latest \
@@ -13,11 +13,11 @@ build:
 		-f Dockerfile.quick \
 		.
 
+# Dockerfile builds Tor from source
 .PHONY: build
-build-alt:
+build:
 	docker buildx build \
 		--platform=linux/amd64,linux/arm,linux/arm64 \
-		--build-arg ALPINE_VERSION=3.17.3 \
 		--build-arg TOR_VERSION=0.4.8.7 \
 		--tag quay.io/bugfest/tor:0.4.8.7 \
 		--tag quay.io/bugfest/tor:latest \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ make
 
 Installs pre-built Tor from Alpine's repositories. Useful for testing/troubleshooting.
 
+WARNING: some Tor features might be missing, depending on the [Alpine community build setup](https://github.com/alpinelinux/aports/tree/master/community/tor)
+
 ```bash
 make quick
 ```


### PR DESCRIPTION


In the new version of the tor project, anti DOS protection has been implemented see: https://community.torproject.org/onion-services/advanced/dos/
This is an essential feature

Great project thanks for keeping it going
